### PR TITLE
openio-sds-swift openio-sds: 

### DIFF
--- a/ubuntu-xenial/openio-sds-swift/debian/changelog
+++ b/ubuntu-xenial/openio-sds-swift/debian/changelog
@@ -1,3 +1,9 @@
+openio-sds-swift (0.7.0.b0-1) xenial; urgency=medium
+
+  * Testing 
+
+ -- Sebastien Lapierre <sebastien.lapierre@openio.io>  Thu, 03 Nov 2016 10:16:00 +0000
+
 openio-sds-swift (0.6.0-1) xenial; urgency=medium
 
   * New upstream release

--- a/ubuntu-xenial/openio-sds-swift/sources
+++ b/ubuntu-xenial/openio-sds-swift/sources
@@ -1,1 +1,1 @@
-https://github.com/open-io/oio-swift/archive/0.6.0.tar.gz  openio-sds-swift_0.6.0.orig.tar.gz
+https://github.com/open-io/oio-swift/archive/0.7.0.b0.tar.gz  openio-sds-swift_0.7.0~b0.orig.tar.gz

--- a/ubuntu-xenial/openio-sds/sources
+++ b/ubuntu-xenial/openio-sds/sources
@@ -1,2 +1,1 @@
-#https://github.com/open-io/oio-sds/archive/3.0.0.c1.tar.gz openio-sds_3.0.0~c1.orig.tar.gz
 https://github.com/open-io/oio-sds/archive/3.1.0.b0.tar.gz openio-sds_3.1.0~b0.orig.tar.gz


### PR DESCRIPTION
Update from 3.0.0 to 3.1.0  for openiosds and from 0.6.0 to 0.7.0 for openio-sds-swift