### PR TITLE
Remove quoting around bash extended regex pattern matching for URI

### DIFF
--- a/oio-debbuild.sh
+++ b/oio-debbuild.sh
@@ -140,7 +140,7 @@ echo "### Building done"
 popd >/dev/null
 echo
 
-if [[ "${REPO}" =~ "^http://" ]]; then
+if [[ "${REPO}" =~ ^http:// ]]; then
     echo "### Uploading package $pkgdsc to repository ${REPO}"
     for f in /var/cache/pbuilder/${OSDISTID}-${OSDISTCODENAME}-${ARCH}/result/$(basename ${pkgdsc} .dsc)*.deb; do
         curl -F "file=@${f}" \


### PR DESCRIPTION
The quotes enable raw string matching instead of regex-based