### PR TITLE
Fix syntax error in script (missing "fi")

### DIFF
--- a/oio-debbuild.sh
+++ b/oio-debbuild.sh
@@ -158,4 +158,5 @@ else
       dput -f -u ${OSDISTID}-arm64-openio-${REPO} /var/cache/pbuilder/${OSDISTID}-${OSDISTCODENAME}-${ARCH}/result/$(basename ${pkgdsc} .dsc)*.changes
     else
       dput -f -u ${OSDISTID}-openio-${REPO} /var/cache/pbuilder/${OSDISTID}-${OSDISTCODENAME}-${ARCH}/result/$(basename ${pkgdsc} .dsc)*.changes
+    fi
 fi


### PR DESCRIPTION
Fixes: commit 4e6794135fbee31bbb0fa36e247472e4e4dae38b