### PR TITLE
Fix package upload for ubuntu xenial arm64

### DIFF
--- a/oio-debbuild.sh
+++ b/oio-debbuild.sh
@@ -159,7 +159,7 @@ if [[ "${REPO}" =~ ^http:// ]]; then
     done
 else
     echo "### Uploading package $pkgdsc to repository ${OSDISTID}-openio-${REPO}"
-    if [ "${OSDISTID}" == 'ubuntu' -a "${ARCH}" == 'arm64' ]; then
+    if [ "${OSDISTID}" == 'ubuntu' -a "${ARCH}" == 'arm64' -a "${REPO}" == "sds-16.10" ]; then
       dput -f -u ${OSDISTID}-arm64-openio-${REPO} /var/cache/pbuilder/${OSDISTID}-${OSDISTCODENAME}-${ARCH}/result/$(basename ${pkgdsc} .dsc)*.changes
     else
       dput -f -u ${OSDISTID}-openio-${REPO} /var/cache/pbuilder/${OSDISTID}-${OSDISTCODENAME}-${ARCH}/result/$(basename ${pkgdsc} .dsc)*.changes


### PR DESCRIPTION
The only special case is sds-16.10 for ubuntu xenial arm64, as shown by:

```
# On buildsys-deb
$ grep '^[[]' /etc/dput.cf | grep arm64
[ubuntu-arm64-openio-sds-16.10]
$
```
The other cases are all handled by the 'ubuntu-openio-sds-*' sections