### PR TITLE
Gridinit: add missing dependencies to pkg : dh-autoreconf

### DIFF
--- a/ubuntu-xenial/openio-gridinit/debian/control
+++ b/ubuntu-xenial/openio-gridinit/debian/control
@@ -2,7 +2,7 @@ Source: openio-gridinit
 Section: unknown
 Priority: optional
 Maintainer: Romain Acciari <romain.acciari@openio.io>
-Build-Depends: debhelper (>= 9), dh-systemd, cmake, libglib2.0-dev, xutils-dev
+Build-Depends: debhelper (>= 9), dh-systemd, cmake, libglib2.0-dev, xutils-dev, dh-autoreconf
 Standards-Version: 3.9.5
 Homepage: <insert the upstream URL, if relevant>
 #Vcs-Git: git://anonscm.debian.org/collab-maint/openio-gridinit.git


### PR DESCRIPTION
This is now needed because of embedded libdill