### PR TITLE
Gridinit: Ensure network is up before starting service

### DIFF
--- a/debian-jessie/openio-gridinit/debian/openio-gridinit.gridinit.service
+++ b/debian-jessie/openio-gridinit/debian/openio-gridinit.gridinit.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Gridinit daemon from OpenIO
-After=syslog.target
+After=syslog.target network.target
 
 [Service]
 User=root

--- a/debian-stretch/openio-gridinit/debian/openio-gridinit.gridinit.service
+++ b/debian-stretch/openio-gridinit/debian/openio-gridinit.gridinit.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Gridinit daemon from OpenIO
-After=syslog.target
+After=syslog.target network.target
 
 [Service]
 User=root

--- a/ubuntu-bionic/openio-gridinit/debian/openio-gridinit.gridinit.service
+++ b/ubuntu-bionic/openio-gridinit/debian/openio-gridinit.gridinit.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Gridinit daemon from OpenIO
-After=syslog.target
+After=syslog.target network.target
 
 [Service]
 User=root

--- a/ubuntu-xenial/openio-gridinit/debian/openio-gridinit.gridinit.service
+++ b/ubuntu-xenial/openio-gridinit/debian/openio-gridinit.gridinit.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Gridinit daemon from OpenIO
-After=syslog.target
+After=syslog.target network.target
 
 [Service]
 User=root


### PR DESCRIPTION
Previous target (syslog.target) didn't require network to be up, meaning that gridinit could start without the proper IP being available. This would cause gridinit managed services to fail to bind to their associated IP:PORTS and break the start on boot behavior.

Related: https://github.com/open-io/rpm-specfiles/pull/185