### PR TITLE
openio-netdata-plugins: new version 0.5.0

### DIFF
--- a/ubuntu-bionic/openio-netdata-plugins/debian/changelog
+++ b/ubuntu-bionic/openio-netdata-plugins/debian/changelog
@@ -1,3 +1,9 @@
+openio-netdata-plugins (0.5.0-1) bionic; urgency=medium
+
+  * New release
+
+ -- Vincent Legoll <vincent.legoll@openio.io>  Mon, 27 May 2019 11:40:19 +0000
+
 openio-netdata-plugins (0.4.0-1) bionic; urgency=medium
 
   * New release

--- a/ubuntu-bionic/openio-netdata-plugins/debian/rules
+++ b/ubuntu-bionic/openio-netdata-plugins/debian/rules
@@ -10,20 +10,27 @@ include /usr/share/dpkg/default.mk
 override_dh_auto_build:
 	cd .. && \
 	wget --no-check-certificate https://github.com/go-redis/redis/archive/v6.12.0.tar.gz && \
+	wget --no-check-certificate https://github.com/aws/aws-sdk-go/archive/v1.19.37.tar.gz && \
 	tar zxf v6.12.0.tar.gz && \
-	mkdir -p go/src/github.com/go-redis && \
+	tar zxf v1.19.37.tar.gz && \
+	mkdir -p go/src/github.com/go-redis go/src/github.com/aws && \
 	ls -l && \
 	cd go/src && \
 	ls -l && \
 	ln -s ../../openio-netdata-plugins-* oionetdata && \
 	cd github.com/go-redis && \
 	ls -l && \
-	ln -s ../../../../redis-* redis
+	ln -s ../../../../redis-* redis && \
+	cd ../.. && \
+	cd github.com/aws && \
+	ls -l && \
+	ln -s ../../../../aws-* aws-sdk-go
 	GOPATH=$(shell pwd)/../go /usr/lib/go-1.10/bin/go build cmd/openio.plugin/openio.plugin.go
 	GOPATH=$(shell pwd)/../go /usr/lib/go-1.10/bin/go build cmd/zookeeper.plugin/zookeeper.plugin.go
 	GOPATH=$(shell pwd)/../go /usr/lib/go-1.10/bin/go build cmd/container.plugin/container.plugin.go
 	GOPATH=$(shell pwd)/../go /usr/lib/go-1.10/bin/go build cmd/command.plugin/command.plugin.go
 	GOPATH=$(shell pwd)/../go /usr/lib/go-1.10/bin/go build cmd/fs.plugin/fs.plugin.go
+	GOPATH=$(shell pwd)/../go /usr/lib/go-1.10/bin/go build cmd/s3roundtrip.plugin/s3roundtrip.plugin.go
 
 override_dh_auto_install:
 	mkdir -pv $(DESTDIR)/usr/lib/x86_64-linux-gnu/netdata/plugins.d
@@ -31,11 +38,7 @@ override_dh_auto_install:
 		openio.plugin \
 		zookeeper.plugin \
 		command.plugin \
-		$(DESTDIR)/usr/lib/x86_64-linux-gnu/netdata/plugins.d
-	# By default netdata will run all the plugins in plugin.d directory, which
-	# is not the intended behavior. The plugins below won't be set executable
-	# by default, and will instead be selectively activated when deploying.
-	install -m 0644 \
 		fs.plugin \
 		container.plugin \
+		s3roundtrip.plugin \
 		$(DESTDIR)/usr/lib/x86_64-linux-gnu/netdata/plugins.d

--- a/ubuntu-bionic/openio-netdata-plugins/sources
+++ b/ubuntu-bionic/openio-netdata-plugins/sources
@@ -1,1 +1,1 @@
-https://github.com/open-io/openio-netdata-plugins/archive/0.4.0.tar.gz openio-netdata-plugins_0.4.0.orig.tar.gz
+https://github.com/open-io/openio-netdata-plugins/archive/0.5.0.tar.gz openio-netdata-plugins_0.5.0.orig.tar.gz

--- a/ubuntu-xenial/openio-netdata-plugins/debian/changelog
+++ b/ubuntu-xenial/openio-netdata-plugins/debian/changelog
@@ -1,3 +1,9 @@
+openio-netdata-plugins (0.5.0-1) xenial; urgency=medium
+
+  * New release
+
+ -- Vincent Legoll <vincent.legoll@openio.io>  Mon, 27 May 2019 15:04:19 +0000
+
 openio-netdata-plugins (0.4.0-1) xenial; urgency=medium
 
   * New release

--- a/ubuntu-xenial/openio-netdata-plugins/debian/rules
+++ b/ubuntu-xenial/openio-netdata-plugins/debian/rules
@@ -10,20 +10,27 @@ include /usr/share/dpkg/default.mk
 override_dh_auto_build:
 	cd .. && \
 	wget --no-check-certificate https://github.com/go-redis/redis/archive/v6.12.0.tar.gz && \
+	wget --no-check-certificate https://github.com/aws/aws-sdk-go/archive/v1.19.37.tar.gz && \
 	tar zxf v6.12.0.tar.gz && \
-	mkdir -p go/src/github.com/go-redis && \
+	tar zxf v1.19.37.tar.gz && \
+	mkdir -p go/src/github.com/go-redis go/src/github.com/aws && \
 	ls -l && \
 	cd go/src && \
 	ls -l && \
 	ln -s ../../openio-netdata-plugins-* oionetdata && \
 	cd github.com/go-redis && \
 	ls -l && \
-	ln -s ../../../../redis-* redis
+	ln -s ../../../../redis-* redis && \
+	cd ../.. && \
+	cd github.com/aws && \
+	ls -l && \
+	ln -s ../../../../aws-* aws-sdk-go
 	GOPATH=$(shell pwd)/../go /usr/lib/go-1.10/bin/go build cmd/openio.plugin/openio.plugin.go
 	GOPATH=$(shell pwd)/../go /usr/lib/go-1.10/bin/go build cmd/zookeeper.plugin/zookeeper.plugin.go
 	GOPATH=$(shell pwd)/../go /usr/lib/go-1.10/bin/go build cmd/container.plugin/container.plugin.go
 	GOPATH=$(shell pwd)/../go /usr/lib/go-1.10/bin/go build cmd/command.plugin/command.plugin.go
 	GOPATH=$(shell pwd)/../go /usr/lib/go-1.10/bin/go build cmd/fs.plugin/fs.plugin.go
+	GOPATH=$(shell pwd)/../go /usr/lib/go-1.10/bin/go build cmd/s3roundtrip.plugin/s3roundtrip.plugin.go
 
 override_dh_auto_install:
 	mkdir -pv $(DESTDIR)/usr/lib/x86_64-linux-gnu/netdata/plugins.d
@@ -31,11 +38,7 @@ override_dh_auto_install:
 		openio.plugin \
 		zookeeper.plugin \
 		command.plugin \
-		$(DESTDIR)/usr/lib/x86_64-linux-gnu/netdata/plugins.d
-	# By default netdata will run all the plugins in plugin.d directory, which
-	# is not the intended behavior. The plugins below won't be set executable
-	# by default, and will instead be selectively activated when deploying.
-	install -m 0644 \
 		fs.plugin \
 		container.plugin \
+		s3roundtrip.plugin \
 		$(DESTDIR)/usr/lib/x86_64-linux-gnu/netdata/plugins.d

--- a/ubuntu-xenial/openio-netdata-plugins/sources
+++ b/ubuntu-xenial/openio-netdata-plugins/sources
@@ -1,1 +1,1 @@
-https://github.com/open-io/openio-netdata-plugins/archive/0.4.0.tar.gz openio-netdata-plugins_0.4.0.orig.tar.gz
+https://github.com/open-io/openio-netdata-plugins/archive/0.5.0.tar.gz openio-netdata-plugins_0.5.0.orig.tar.gz


### PR DESCRIPTION
* new plugin: S3 roundtrip
* new dependency: aws-sdk-go 1.19.37
* install all plugins as executable files, disabling will be handled
  through netdata configuration