### PR TITLE
OpenIO-asn1c: Add conflict with asn1c

### DIFF
--- a/ubuntu-bionic/openio-asn1c/debian/control
+++ b/ubuntu-bionic/openio-asn1c/debian/control
@@ -11,6 +11,7 @@ Homepage: <insert the upstream URL, if relevant>
 Package: openio-asn1c
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
+Conflicts: asn1c
 Description: Free, Open Source ASN.1 compiler
  Compiles ASN.1 data structures into C source structures that can be
  simply marshalled to/unmarshalled from: BER, DER, CER, BASIC-XER,


### PR DESCRIPTION
This will help with future replacement of openio-asn1c with the community-maintained asn1c.