### PR TITLE
gridinit: set API_VERSION explicitly

### DIFF
--- a/ubuntu-bionic/openio-gridinit/debian/changelog
+++ b/ubuntu-bionic/openio-gridinit/debian/changelog
@@ -1,3 +1,9 @@
+openio-gridinit (2.2.0-1) bionic; urgency=medium
+
+  * New release
+
+ -- Florent Vennetier <florent.vennetier@ovhcloud.com>  Tue, 12 Jan 2021 18:04:27 +0000
+
 openio-gridinit (2.0.2-4) bionic; urgency=medium
 
   * New release

--- a/ubuntu-bionic/openio-gridinit/debian/control
+++ b/ubuntu-bionic/openio-gridinit/debian/control
@@ -1,7 +1,7 @@
 Source: openio-gridinit
 Section: unknown
 Priority: optional
-Maintainer: Romain Acciari <romain.acciari@openio.io>
+Maintainer: Jérôme Loyet <jerome.loyet@ovhcloud.com>
 Build-Depends: debhelper (>= 9), dh-systemd, cmake, libglib2.0-dev, xutils-dev
 Standards-Version: 3.9.5
 Homepage: <insert the upstream URL, if relevant>

--- a/ubuntu-bionic/openio-gridinit/debian/rules
+++ b/ubuntu-bionic/openio-gridinit/debian/rules
@@ -3,6 +3,7 @@
 # output every command that modifies files on the build system.
 DH_VERBOSE = 1
 export DH_OPTIONS=-v
+VERSION ?= $(shell dpkg-parsechangelog --show-field Version | sed "s/-.*$$//" | sed "s/^[0-9]*://")
 
 # see EXAMPLES in dpkg-buildflags(1) and read /usr/share/dpkg/*
 DPKG_EXPORT_BUILDFLAGS = 1
@@ -27,7 +28,8 @@ override_dh_installinit:
 
 override_dh_auto_configure:
 	dh_auto_configure -- \
-	-DPREFIX=/usr \
+	-DAPI_VERSION=$(VERSION) \
+	-DCMAKE_INSTALL_PREFIX=/usr \
 	-DLD_LIBDIR=lib \
 	-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 	-DGRIDINIT_SOCK_PATH="/run/gridinit/gridinit.sock"

--- a/ubuntu-bionic/openio-gridinit/sources
+++ b/ubuntu-bionic/openio-gridinit/sources
@@ -1,1 +1,1 @@
-https://github.com/open-io/gridinit/archive/2.0.2.tar.gz openio-gridinit_2.0.2.orig.tar.gz
+https://github.com/open-io/gridinit/archive/2.2.0.tar.gz openio-gridinit_2.2.0.orig.tar.gz

--- a/ubuntu-xenial/openio-gridinit/debian/changelog
+++ b/ubuntu-xenial/openio-gridinit/debian/changelog
@@ -1,3 +1,9 @@
+openio-gridinit (2.2.0-1) xenial; urgency=medium
+
+  * New release
+
+ -- Florent Vennetier <florent.vennetier@ovhcloud.com>  Tue, 12 Jan 2021 18:04:27 +0000
+
 openio-gridinit (2.0.2-4) xenial; urgency=medium
 
   * New release

--- a/ubuntu-xenial/openio-gridinit/debian/rules
+++ b/ubuntu-xenial/openio-gridinit/debian/rules
@@ -3,6 +3,7 @@
 # output every command that modifies files on the build system.
 DH_VERBOSE = 1
 export DH_OPTIONS=-v
+VERSION ?= $(shell dpkg-parsechangelog --show-field Version | sed "s/-.*$$//" | sed "s/^[0-9]*://")
 
 # see EXAMPLES in dpkg-buildflags(1) and read /usr/share/dpkg/*
 DPKG_EXPORT_BUILDFLAGS = 1
@@ -27,7 +28,8 @@ override_dh_installinit:
 
 override_dh_auto_configure:
 	dh_auto_configure -- \
-	-DPREFIX=/usr \
+	-DAPI_VERSION=$(VERSION) \
+	-DCMAKE_INSTALL_PREFIX=/usr \
 	-DLD_LIBDIR=lib \
 	-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 	-DGRIDINIT_SOCK_PATH="/run/gridinit/gridinit.sock"

--- a/ubuntu-xenial/openio-gridinit/sources
+++ b/ubuntu-xenial/openio-gridinit/sources
@@ -1,1 +1,1 @@
-https://github.com/open-io/gridinit/archive/2.0.2.tar.gz openio-gridinit_2.0.2.orig.tar.gz
+https://github.com/open-io/gridinit/archive/2.2.0.tar.gz openio-gridinit_2.2.0.orig.tar.gz


### PR DESCRIPTION
Update to 2.2.0, and explicitly set API_VERSION so it is correct when users run `gridinit --version`.